### PR TITLE
Add RSA-RAW support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ const variants = [
 ]
 ```
 
+#### Platform specific configuration
+
+By default, this library uses the [WebCrypto API](https://w3c.github.io/webcrypto/). Certain platforms, such as [Cloudflare Workers](https://github.com/cloudflare/workerd/blob/6b63c701e263a311c2a3ce64e2aeada69afc32a1/src/workerd/api/crypto-impl-asymmetric.c%2B%2B#L827-L868), have implemented native operation. These can be enabled by passing `{ supportRSARAW: true }` when retrieving a suite.
+At the time of writing, this dedicated optimisation is done only for the `BlindSign` operation. Key type does not have to be modified, and will be set to `RSA-RAW` by the library for the time of the operation.
+
 
 #### Setup
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,12 @@
 //
 // RFC9474: https://www.rfc-editor.org/info/rfc9474
 
-import { BlindRSA, PrepareType, type BlindRSAParams } from './blindrsa.js';
+import {
+    BlindRSA,
+    PrepareType,
+    type BlindRSAParams,
+    type BlindRSAPlatformParams,
+} from './blindrsa.js';
 
 export { BlindRSA, type BlindRSAParams };
 
@@ -53,20 +58,27 @@ export const RSABSSA = {
             algorithm: Pick<RsaHashedKeyGenParams, 'modulusLength' | 'publicExponent'>,
         ): Promise<CryptoKeyPair> => BlindRSA.generateKey({ ...algorithm, hash: 'SHA-384' }),
         PSS: {
-            Randomized: () => new BlindRSA(Params.RSABSSA_SHA384_PSS_Randomized),
-            Deterministic: () => new BlindRSA(Params.RSABSSA_SHA384_PSS_Deterministic),
+            Randomized: (params: BlindRSAPlatformParams = { supportsRSARAW: false }) =>
+                new BlindRSA({ ...Params.RSABSSA_SHA384_PSS_Randomized, ...params }),
+            Deterministic: (params: BlindRSAPlatformParams = { supportsRSARAW: false }) =>
+                new BlindRSA({ ...Params.RSABSSA_SHA384_PSS_Deterministic, ...params }),
         },
         PSSZero: {
-            Randomized: () => new BlindRSA(Params.RSABSSA_SHA384_PSSZERO_Randomized),
-            Deterministic: () => new BlindRSA(Params.RSABSSA_SHA384_PSSZERO_Deterministic),
+            Randomized: (params: BlindRSAPlatformParams = { supportsRSARAW: false }) =>
+                new BlindRSA({ ...Params.RSABSSA_SHA384_PSSZERO_Randomized, ...params }),
+            Deterministic: (params: BlindRSAPlatformParams = { supportsRSARAW: false }) =>
+                new BlindRSA({ ...Params.RSABSSA_SHA384_PSSZERO_Deterministic, ...params }),
         },
     },
 } as const;
 
-export function getSuiteByName(name: string): BlindRSA {
+export function getSuiteByName(
+    name: string,
+    params: BlindRSAPlatformParams = { supportsRSARAW: false },
+): BlindRSA {
     for (const suiteParams of Object.values(Params)) {
         if (name.toLowerCase() === suiteParams.name.toLowerCase()) {
-            return new BlindRSA(suiteParams);
+            return new BlindRSA({ ...suiteParams, ...params });
         }
     }
 

--- a/test/blindrsa.test.ts
+++ b/test/blindrsa.test.ts
@@ -147,10 +147,12 @@ describe.each(vectors)('TestVectors', (v: Vector) => {
             .mockReturnValueOnce(rBytes); // mock for random blind
     });
 
-    test(
+    const params = [[], [{ supportsRSARAW: true }]];
+
+    test.each(params)(
         `${v.name}`,
-        async () => {
-            const blindRSA = getSuiteByName(v.name);
+        async (...params) => {
+            const blindRSA = getSuiteByName(v.name, ...params);
             expect(blindRSA.toString()).toBe(v.name);
 
             const msg = hexToUint8(v.msg);

--- a/test/jest.setup-file.ts
+++ b/test/jest.setup-file.ts
@@ -3,7 +3,36 @@
 
 // Mocking crypto with NodeJS WebCrypto module only for tests.
 import { webcrypto } from 'node:crypto';
+import { RSABSSA } from '../src';
+
+// RSA-RAW is not supported by WebCrypto, so we need to mock it.
+// blindSign operation is similar for deterministic and randomized variants, and salt length is not used during this operation.
+// It matches cloudflare/workerd implementation https://github.com/cloudflare/workerd/blob/6b63c701e263a311c2a3ce64e2aeada69afc32a1/src/workerd/api/crypto-impl-asymmetric.c%2B%2B#L827-L868
+async function mockSign(
+    algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams,
+    key: CryptoKey,
+    data: Uint8Array,
+): Promise<ArrayBuffer> {
+    if (
+        algorithm === 'RSA-RAW' ||
+        (typeof algorithm !== 'string' && algorithm?.name === 'RSA-RAW')
+    ) {
+        const algorithmName = key.algorithm.name;
+        if (algorithmName !== 'RSA-RAW') {
+            throw new Error(`Invalid key algorithm: ${algorithmName}`);
+        }
+        key.algorithm.name = 'RSA-PSS';
+        try {
+            return RSABSSA.SHA384.PSSZero.Deterministic().blindSign(key, data);
+        } finally {
+            key.algorithm.name = algorithmName;
+        }
+    }
+    return webcrypto.subtle.sign(algorithm, key, data);
+}
 
 if (typeof crypto === 'undefined') {
     Object.assign(global, { crypto: webcrypto });
 }
+
+crypto.subtle.sign = mockSign;


### PR DESCRIPTION
Cloudflare Workers provides native support for blind signing operation. The performance improvement is noticeable.
The operation is provided on a specific algorithm `RSA-RAW`, non-WebCrypto standardised.

This commit adds support for this algorithm. The downstream client of the library can specify if their platform support such algorithm.