### PR TITLE
Release 0.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@cloudflare/blindrsa-ts",
-    "version": "0.2.0",
+    "version": "0.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@cloudflare/blindrsa-ts",
-            "version": "0.2.0",
+            "version": "0.3.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "sjcl": "1.0.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cloudflare/blindrsa-ts",
-    "version": "0.2.0",
+    "version": "0.3.1",
     "description": "blindrsa-ts: A TypeScript Library for the RSA Blind Signature Protocol",
     "author": "Armando Faz <armfazh@cloudflare.com>",
     "maintainers": [


### PR DESCRIPTION
Bump package.json version

CI could not publish 0.3.0 due to an error in package.json, version being set to 0.1.0. This addresses this issue by cutting a new release 0.3.1