### PR TITLE
Fix sjcl types for released package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@cloudflare/blindrsa-ts",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@cloudflare/blindrsa-ts",
-            "version": "0.4.0",
+            "version": "0.4.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "sjcl": "1.0.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cloudflare/blindrsa-ts",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "blindrsa-ts: A TypeScript Library for the Blind RSA Signature Protocol",
     "author": "Armando Faz <armfazh@cloudflare.com>",
     "maintainers": [
@@ -28,7 +28,7 @@
         "node": ">=18"
     },
     "scripts": {
-        "build": "tsc -b",
+        "build": "tsc -b && cp src/sjcl/index.d.ts lib/src/sjcl/index.d.ts",
         "test": "tsc -b test && node --experimental-vm-modules node_modules/jest/bin/jest.js --ci",
         "lint": "eslint .",
         "format": "prettier './(src|test|examples)/**/!(*.d).ts' --write",


### PR DESCRIPTION
sjcl types are not part of the output in the build step, and are therefore not included in the resulting package.
This commit copies these types so dependencies don't error when using `@cloudflare/blindrsa-ts`.

Also prepares fix release 0.4.1