### PR TITLE
Fix sjcl import by declaring a default

### DIFF
--- a/src/sjcl/index.d.ts
+++ b/src/sjcl/index.d.ts
@@ -1443,3 +1443,24 @@ export namespace random {
 
 }
 
+// export default with all above namespaces
+declare namespace sjcl {
+    export {
+        bn,
+        prng,
+        codec,
+        keyexchange,
+        mode,
+        decrypt,
+        encrypt,
+        bitArray,
+        cipher,
+        exception,
+        hash,
+        json,
+        misc,
+        random,
+    }
+}
+
+export default sjcl;


### PR DESCRIPTION
sjcl does not export a default in typescript. This commit updates the import to allow downsteram library to not complain about typescript type definitions.