### PR TITLE
Add support notice for Partially Blind RSA signature verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,14 @@ const variants = [
 
 #### Platform specific configuration
 
+**Optimizations**
+
 By default, this library uses the [WebCrypto API](https://w3c.github.io/webcrypto/). Certain platforms, such as [Cloudflare Workers](https://github.com/cloudflare/workerd/blob/6b63c701e263a311c2a3ce64e2aeada69afc32a1/src/workerd/api/crypto-impl-asymmetric.c%2B%2B#L827-L868), have implemented native operation. These can be enabled by passing `{ supportRSARAW: true }` when retrieving a suite.
 At the time of writing, this dedicated optimization is done only for the `BlindSign` operation. Key type does not have to be modified, and will be set to `RSA-RAW` by the library for the time of the operation.
+
+**Partially Blind RSA verification**
+
+This library does not support Partially Blind RSA signature verification in browser. This is due to [`crypto.subtle`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/subtle) implementations not allowing large public exponents required by Partially Blind RSA. You can follow bugs for [Chromium](https://issues.chromium.org/issues/340178598) and [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1896444).
 
 #### Setup
 


### PR DESCRIPTION
It's not supported in browser. Surface the bug in the README to allow for better discovery.