### PR TITLE
Remove advanced CodeQL

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,21 +40,4 @@ jobs:
 
       - name: Check examples
         run: npm run examples
-  analyze:
-    name: Analyze CodeQL
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: javascript-typescript
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+


### PR DESCRIPTION
This repository does not support advanced CodeQl analysis. It is disabled at the organisation level. Removing the build from GitHub Actions workflow to avoid false positive.