### PR TITLE
Fix use of RSA-RAW key when supported

### DIFF
--- a/src/blindrsa.ts
+++ b/src/blindrsa.ts
@@ -8,6 +8,7 @@ import {
     i2osp,
     is_coprime,
     joinAll,
+    NATIVE_SUPPORT_NAME,
     os2ip,
     random_integer_uniform,
     rsaRawBlingSign,
@@ -70,7 +71,14 @@ export class BlindRSA {
         modulusLengthBytes: number;
         hash: string;
     }> {
-        if (key.type !== type || key.algorithm.name !== BlindRSA.NAME) {
+        if (key.type !== type) {
+            throw new Error(`key is not ${type}`);
+        }
+        const algorithmNames = [BlindRSA.NAME];
+        if (this.params.supportsRSARAW) {
+            algorithmNames.push(NATIVE_SUPPORT_NAME);
+        }
+        if (!algorithmNames.includes(key.algorithm.name)) {
             throw new Error(`key is not ${BlindRSA.NAME}`);
         }
         if (!key.extractable) {

--- a/src/partially_blindrsa.ts
+++ b/src/partially_blindrsa.ts
@@ -17,6 +17,7 @@ import {
     rsavp1,
     inverseMod,
     rsaRawBlingSign,
+    NATIVE_SUPPORT_NAME,
     prepare_sjcl_random_generator,
     type BigPublicKey,
     type BigSecretKey,
@@ -67,7 +68,14 @@ export class PartiallyBlindRSA {
         modulusLengthBytes: number;
         hash: string;
     }> {
-        if (key.type !== type || key.algorithm.name !== PartiallyBlindRSA.NAME) {
+        if (key.type !== type) {
+            throw new Error(`key is not ${type}`);
+        }
+        const algorithmNames = [PartiallyBlindRSA.NAME];
+        if (this.params.supportsRSARAW) {
+            algorithmNames.push(NATIVE_SUPPORT_NAME);
+        }
+        if (!algorithmNames.includes(key.algorithm.name)) {
             throw new Error(`key is not ${PartiallyBlindRSA.NAME}`);
         }
         if (!key.extractable) {


### PR DESCRIPTION
`extractKeyParams` should check if supportRSARaw is set. If so, it should allow for `RSA-RAW` algorithm name.