### PR TITLE
Directly return platform signature for blindrsa

### DIFF
--- a/src/partially_blindrsa.ts
+++ b/src/partially_blindrsa.ts
@@ -17,7 +17,6 @@ import {
     rsavp1,
     inverseMod,
     rsaRawBlingSign,
-    NATIVE_SUPPORT_NAME,
     prepare_sjcl_random_generator,
     type BigPublicKey,
     type BigSecretKey,
@@ -68,14 +67,7 @@ export class PartiallyBlindRSA {
         modulusLengthBytes: number;
         hash: string;
     }> {
-        if (key.type !== type) {
-            throw new Error(`key is not ${type}`);
-        }
-        const algorithmNames = [PartiallyBlindRSA.NAME];
-        if (this.params.supportsRSARAW) {
-            algorithmNames.push(NATIVE_SUPPORT_NAME);
-        }
-        if (!algorithmNames.includes(key.algorithm.name)) {
+        if (key.type !== type || key.algorithm.name !== PartiallyBlindRSA.NAME) {
             throw new Error(`key is not ${PartiallyBlindRSA.NAME}`);
         }
         if (!key.extractable) {
@@ -197,7 +189,7 @@ export class PartiallyBlindRSA {
                 },
                 true,
             );
-            s = await rsaRawBlingSign(privateKey, blindMsg);
+            s = os2ip(await rsaRawBlingSign(privateKey, blindMsg));
         } else {
             s = rsasp1(sk_derived, m);
         }

--- a/src/util.ts
+++ b/src/util.ts
@@ -318,7 +318,7 @@ export const NATIVE_SUPPORT_NAME = 'RSA-RAW';
 export async function rsaRawBlingSign(
     privateKey: CryptoKey,
     blindMsg: Uint8Array,
-): Promise<sjcl.BigNumber> {
+): Promise<Uint8Array> {
     if (privateKey.algorithm.name !== NATIVE_SUPPORT_NAME) {
         privateKey = await crypto.subtle.importKey(
             'pkcs8',
@@ -333,7 +333,7 @@ export async function rsaRawBlingSign(
         privateKey,
         blindMsg,
     );
-    return os2ip(new Uint8Array(signature));
+    return new Uint8Array(signature);
 }
 
 export type BigPublicKey = { e: sjcl.BigNumber; n: sjcl.BigNumber };


### PR DESCRIPTION
This is faster, avoids exports, and allows to work when only signature is implemented and not full JWK export