### PR TITLE
0.4.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@cloudflare/blindrsa-ts",
-    "version": "0.4.5",
+    "version": "0.4.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@cloudflare/blindrsa-ts",
-            "version": "0.4.5",
+            "version": "0.4.6",
             "license": "Apache-2.0",
             "dependencies": {
                 "sjcl": "1.0.9"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cloudflare/blindrsa-ts",
-    "version": "0.4.5",
+    "version": "0.4.6",
     "description": "blindrsa-ts: A TypeScript Library for the Blind RSA Signature Protocol",
     "author": "Armando Faz <armfazh@cloudflare.com>",
     "maintainers": [


### PR DESCRIPTION
The diff is mostly bumping vulnerable dependencies. I'll cut the release through github after that

See https://github.com/cloudflare/blindrsa-ts/commits/main/